### PR TITLE
 Fix - script crashes if there is no pinned giveaways 

### DIFF
--- a/sg.py
+++ b/sg.py
@@ -461,8 +461,8 @@ i_want_to_sleep = False
 forbidden_words = (" ban", " fake", " bot", " not enter", " don't enter")
 good_words = (" bank", " banan", " both", " band", " banner", " bang")
 giveaways_from_banner = []
-if not need_giveaways_from_banners:
-    get_games_from_banners()
+#if not need_giveaways_from_banners:
+#    get_games_from_banners()
 print("Total coins:", get_coins(get_requests(cookie, "coins_check")))
 
 while True:

--- a/sg.py
+++ b/sg.py
@@ -466,8 +466,8 @@ if not need_giveaways_from_banners:
 print("Total coins:", get_coins(get_requests(cookie, "coins_check")))
 
 while True:
-    if not need_giveaways_from_banners:
-        get_games_from_banners()
+#    if not need_giveaways_from_banners:
+#        get_games_from_banners()
     i_want_to_sleep = False
     requests_result = get_requests(cookie, func_list[chose])
     chose += 1


### PR DESCRIPTION
If there is no pinned giveaways (at top of list):

`You are using the latest version of the program. You version: 1.3.0
Traceback (most recent call last):
  File "/opt/steam_gifts_bot/sg.py", line 465, in <module>
    get_games_from_banners()
  File "/opt/steam_gifts_bot/sg.py", line 418, in get_games_from_ba
    banners = soup.find(class_="pinned-giveaways__inner-wrap pinned
    AttributeError: 'NoneType' object has no attribute 'find_all'
`

Is commented out in PR code really needed?